### PR TITLE
#feat3 community

### DIFF
--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -1,9 +1,6 @@
 package com.ottrade.ottrade.domain.community.controller;
 
-import com.ottrade.ottrade.domain.community.dto.BoardDetailRespDTO;
-import com.ottrade.ottrade.domain.community.dto.BoardUpdateReqDTO;
-import com.ottrade.ottrade.domain.community.dto.BoardUpdateRespDTO;
-import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
+import com.ottrade.ottrade.domain.community.dto.*;
 import com.ottrade.ottrade.domain.community.entity.Board;
 import com.ottrade.ottrade.domain.community.service.BoardService;
 import com.ottrade.ottrade.util.api.ApiResponse;
@@ -11,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -50,10 +49,27 @@ public class Controller {
         return new ResponseEntity<>(ApiResponse.success("삭제완", HttpStatus.OK), HttpStatus.OK);
     }
 
-    // 게시글 자세히 보기
+    // 게시글 상세 조회
     @GetMapping("/detail/{boardId}")
     public ResponseEntity<?> getBoardDetail(@PathVariable Long boardId) {
         BoardDetailRespDTO boardDetailRespDTO = boardService.detailBoard(boardId);
         return new ResponseEntity<>(ApiResponse.success(boardDetailRespDTO, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    /**
+     * 댓글 작성
+     * - 회원 인증 필요
+     * - Authorization 헤더 Bearer 토큰 필요
+     */
+    @PostMapping("/{boardId}/{userId}/comments")
+    public ResponseEntity<CommentDTO> createComment(
+            @PathVariable Long boardId, @PathVariable Long userId,
+//            @RequestHeader("Authorization") String token,
+            @RequestBody CommentCreateRequest request
+    ) {
+        CommentDTO created = boardService.createComment(boardId, request, userId);
+        return ResponseEntity
+                .created(URI.create("/api/boards/" + boardId + "/comments/" + created.getCommentId()))
+                .body(created);
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -84,6 +85,27 @@ public class Controller {
         return new ResponseEntity<>(ApiResponse.success("댓글이 삭제되었습니다.", HttpStatus.OK), HttpStatus.OK);
     }
 
+    /**
+     * 게시글 좋아요
+     */
+    @PostMapping("/{boardId}/{userId}/like")
+    public ResponseEntity<?> addLike(@PathVariable Long boardId, @PathVariable Long userId) {
+        boardService.addLike(boardId, userId);
+        return new ResponseEntity<>(ApiResponse.success("좋아요가 추가되었습니다.", HttpStatus.OK), HttpStatus.OK);
+    }
 
+    /**
+     * 게시글 좋아요 취소
+     */
+    @DeleteMapping("/{boardId}/{userId}/like")
+    public ResponseEntity<?> removeLike(@PathVariable Long boardId, @PathVariable Long userId) {
+        boardService.removeLike(boardId, userId);
+        return new ResponseEntity<>(ApiResponse.success("좋아요가 취소되었습니다.", HttpStatus.OK), HttpStatus.OK);
+    }
 
+    @GetMapping("/hot")
+    public ResponseEntity<?> getHotBoards() {
+        List<AllBoardRespDTO> hotBoards = boardService.getHotBoards();
+        return new ResponseEntity<>(ApiResponse.success(hotBoards, HttpStatus.OK), HttpStatus.OK);
+    }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -119,4 +119,13 @@ public class Controller {
         List<AllBoardRespDTO> searchResults = boardService.searchBoards(keyword);
         return new ResponseEntity<>(ApiResponse.success(searchResults, HttpStatus.OK), HttpStatus.OK);
     }
+
+    /**
+     * 총 사용자 및 게시글 수 통계 조회
+     */
+    @GetMapping("/stats")
+    public ResponseEntity<?> getTotalStats() {
+        TotalStatsDTO stats = boardService.getTotalStats();
+        return new ResponseEntity<>(ApiResponse.success(stats, HttpStatus.OK), HttpStatus.OK);
+    }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -25,7 +25,7 @@ public class Controller {
     }
 
     // 게시글 전체 목록 조회..type(free,info게시판 등등)
-    @GetMapping("/")
+    @GetMapping
     public ResponseEntity<?> getBoard(@RequestParam("type") String type) {
         return new ResponseEntity<>(ApiResponse.success(boardService.allBoard(type), HttpStatus.OK), HttpStatus.OK);
     }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -15,13 +15,15 @@ public class Controller {
 
     private final BoardService boardService;
 
+    // 게시글 작성
     @PostMapping("/write")
     public ResponseEntity<?> boardWrite(@RequestBody BoardWriteDTO boardWriteDTO) {
         return new ResponseEntity<>(ApiResponse.success(boardService.boardWrite(boardWriteDTO), HttpStatus.CREATED), HttpStatus.CREATED);
     }
 
+    // 게시글 전체 목록 조회..type(free,info게시판 등등)
     @GetMapping("/")
-    public ResponseEntity<?> getBoard(@RequestParam String type) {
+    public ResponseEntity<?> getBoard(@RequestParam("type") String type) {
         return new ResponseEntity<>(ApiResponse.success(boardService.allBoard(type), HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -1,5 +1,6 @@
 package com.ottrade.ottrade.domain.community.controller;
 
+import com.ottrade.ottrade.domain.community.dto.BoardDetailRespDTO;
 import com.ottrade.ottrade.domain.community.dto.BoardUpdateReqDTO;
 import com.ottrade.ottrade.domain.community.dto.BoardUpdateRespDTO;
 import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
@@ -40,5 +41,19 @@ public class Controller {
 
         // 응답 DTO를 반환
         return new ResponseEntity<>(ApiResponse.success(responseDTO, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/delete/{boardId}")
+    public ResponseEntity<?> deleteBoard(@PathVariable Long boardId) {
+        boardService.deleteBoard(boardId);
+        return new ResponseEntity<>(ApiResponse.success("삭제완", HttpStatus.OK), HttpStatus.OK);
+    }
+
+    // 게시글 자세히 보기
+    @GetMapping("/detail/{boardId}")
+    public ResponseEntity<?> getBoardDetail(@PathVariable Long boardId) {
+        BoardDetailRespDTO boardDetailRespDTO = boardService.detailBoard(boardId);
+        return new ResponseEntity<>(ApiResponse.success(boardDetailRespDTO, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -1,6 +1,9 @@
 package com.ottrade.ottrade.domain.community.controller;
 
+import com.ottrade.ottrade.domain.community.dto.BoardUpdateReqDTO;
+import com.ottrade.ottrade.domain.community.dto.BoardUpdateRespDTO;
 import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
+import com.ottrade.ottrade.domain.community.entity.Board;
 import com.ottrade.ottrade.domain.community.service.BoardService;
 import com.ottrade.ottrade.util.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +28,17 @@ public class Controller {
     @GetMapping("/")
     public ResponseEntity<?> getBoard(@RequestParam("type") String type) {
         return new ResponseEntity<>(ApiResponse.success(boardService.allBoard(type), HttpStatus.OK), HttpStatus.OK);
+    }
+
+    //게시글 수정
+    @PutMapping("/update")
+    public ResponseEntity<?> updateBoard(@RequestBody BoardUpdateReqDTO boardUpdateReqDTO) {
+        // 서비스는 엔티티를 반환
+        Board updatedBoard = boardService.updateBoard(boardUpdateReqDTO);
+        // 컨트롤러에서 엔티티를 응답 DTO로 변환
+        BoardUpdateRespDTO responseDTO = BoardUpdateRespDTO.fromEntity(updatedBoard);
+
+        // 응답 DTO를 반환
+        return new ResponseEntity<>(ApiResponse.success(responseDTO, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -1,0 +1,23 @@
+package com.ottrade.ottrade.domain.community.controller;
+
+import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
+import com.ottrade.ottrade.domain.community.service.BoardService;
+import com.ottrade.ottrade.util.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/board")
+public class Controller {
+
+    private final BoardService boardService;
+
+    @PostMapping("/write")
+    public ResponseEntity<?> boardWrite(@RequestBody BoardWriteDTO boardWriteDTO) {
+        return new ResponseEntity<>(ApiResponse.success(boardService.boardWrite(boardWriteDTO), HttpStatus.CREATED), HttpStatus.CREATED);
+    }
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -72,4 +72,18 @@ public class Controller {
                 .created(URI.create("/api/boards/" + boardId + "/comments/" + created.getCommentId()))
                 .body(created);
     }
+
+    /**
+     * 댓글 삭제
+     * - 대댓글이 있으면 "삭제된 댓글입니다."로 내용 변경
+     * - 대댓글이 없으면 DB에서 삭제
+     */
+    @DeleteMapping("/{boardId}/comments/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long boardId, @PathVariable Long commentId) {
+        boardService.deleteComment(commentId);
+        return new ResponseEntity<>(ApiResponse.success("댓글이 삭제되었습니다.", HttpStatus.OK), HttpStatus.OK);
+    }
+
+
+
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -108,4 +108,15 @@ public class Controller {
         List<AllBoardRespDTO> hotBoards = boardService.getHotBoards();
         return new ResponseEntity<>(ApiResponse.success(hotBoards, HttpStatus.OK), HttpStatus.OK);
     }
+
+    /**
+     * 게시글 검색 (제목 + 내용)
+     * @param keyword 검색어
+     * @return 검색 결과 목록
+     */
+    @GetMapping("/search")
+    public ResponseEntity<?> searchBoards(@RequestParam("keyword") String keyword) {
+        List<AllBoardRespDTO> searchResults = boardService.searchBoards(keyword);
+        return new ResponseEntity<>(ApiResponse.success(searchResults, HttpStatus.OK), HttpStatus.OK);
+    }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/controller/Controller.java
@@ -20,4 +20,8 @@ public class Controller {
         return new ResponseEntity<>(ApiResponse.success(boardService.boardWrite(boardWriteDTO), HttpStatus.CREATED), HttpStatus.CREATED);
     }
 
+    @GetMapping("/")
+    public ResponseEntity<?> getBoard(@RequestParam String type) {
+        return new ResponseEntity<>(ApiResponse.success(boardService.allBoard(type), HttpStatus.OK), HttpStatus.OK);
+    }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/AllBoardRespDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/AllBoardRespDTO.java
@@ -1,12 +1,17 @@
 package com.ottrade.ottrade.domain.community.dto;
 
-import com.ottrade.ottrade.domain.community.entity.Comment;
-import com.ottrade.ottrade.domain.community.entity.PostLike;
+import com.ottrade.ottrade.domain.community.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
-import java.util.LinkedHashSet;
-import java.util.Set;
 
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class AllBoardRespDTO {
 
     private Long id;
@@ -17,5 +22,17 @@ public class AllBoardRespDTO {
     private int view_count;
     private Timestamp created_at;
     private String status;
+
+    public static AllBoardRespDTO fromEntity(Board board) {
+        AllBoardRespDTO dto = new AllBoardRespDTO();
+        dto.id = board.getId();
+        dto.title = board.getTitle();
+        dto.content = board.getContent();
+        dto.type = board.getType();
+        dto.view_count = board.getView_count();
+        dto.created_at = board.getCreated_at();
+        dto.status = board.getStatus();
+        return dto;
+    }
 
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/AllBoardRespDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/AllBoardRespDTO.java
@@ -1,0 +1,21 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import com.ottrade.ottrade.domain.community.entity.Comment;
+import com.ottrade.ottrade.domain.community.entity.PostLike;
+
+import java.sql.Timestamp;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class AllBoardRespDTO {
+
+    private Long id;
+    private Long user_id;
+    private String title;
+    private String content;
+    private String type;
+    private int view_count;
+    private Timestamp created_at;
+    private String status;
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/AllBoardRespDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/AllBoardRespDTO.java
@@ -29,8 +29,8 @@ public class AllBoardRespDTO {
         dto.title = board.getTitle();
         dto.content = board.getContent();
         dto.type = board.getType();
-        dto.view_count = board.getView_count();
-        dto.created_at = board.getCreated_at();
+        dto.view_count = board.getViewCount();
+        dto.created_at = board.getCreatedAt();
         dto.status = board.getStatus();
         return dto;
     }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardDetailRespDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardDetailRespDTO.java
@@ -1,0 +1,22 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardDetailRespDTO {
+
+    private Long boardId;
+    private String title;
+    private String content;
+    private Long user_id;
+    private List<CommentDTO> comment;
+    private int postLikeCount;
+
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardUpdateReqDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardUpdateReqDTO.java
@@ -1,0 +1,16 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardUpdateReqDTO {
+
+    private Long id;
+    private String title;
+    private String content;
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardUpdateRespDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardUpdateRespDTO.java
@@ -9,7 +9,6 @@ public class BoardUpdateRespDTO {
     private final Long id;
     private final String title;
     private final String content;
-    // 필요하다면 수정 시간 등 추가 정보를 넣을 수 있습니다.
 
     // Board 엔티티를 DTO로 변환하는 정적 팩토리 메소드
     public static BoardUpdateRespDTO fromEntity(Board board) {

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardUpdateRespDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardUpdateRespDTO.java
@@ -1,0 +1,25 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import com.ottrade.ottrade.domain.community.entity.Board;
+import lombok.Getter;
+
+@Getter
+public class BoardUpdateRespDTO {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    // 필요하다면 수정 시간 등 추가 정보를 넣을 수 있습니다.
+
+    // Board 엔티티를 DTO로 변환하는 정적 팩토리 메소드
+    public static BoardUpdateRespDTO fromEntity(Board board) {
+        return new BoardUpdateRespDTO(board.getId(), board.getTitle(), board.getContent());
+    }
+
+    // 생성자
+    private BoardUpdateRespDTO(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardWriteDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/BoardWriteDTO.java
@@ -1,0 +1,15 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BoardWriteDTO {
+
+    private Long user_id;
+    private String title;
+    private String content;
+    private String type;
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentCreateRequest.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentCreateRequest.java
@@ -1,0 +1,8 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import lombok.Data;
+
+@Data
+public class CommentCreateRequest {
+    private String content;
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentCreateRequest.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentCreateRequest.java
@@ -5,4 +5,6 @@ import lombok.Data;
 @Data
 public class CommentCreateRequest {
     private String content;
+    private Long parentId; // 부모 댓글 ID 필드 추가
+
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentDTO.java
@@ -1,0 +1,17 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentDTO {
+    private Long commentId;
+    private Long user_id;      // 댓글 작성자 ID
+    private String content;
+    private Timestamp createdAt;
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/CommentDTO.java
@@ -1,10 +1,13 @@
 package com.ottrade.ottrade.domain.community.dto;
 
+import com.ottrade.ottrade.domain.community.entity.Comment;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor
@@ -14,4 +17,19 @@ public class CommentDTO {
     private Long user_id;      // 댓글 작성자 ID
     private String content;
     private Timestamp createdAt;
+    private List<CommentDTO> children; // 대댓글 DTO 리스트 추가
+
+    // 엔티티를 DTO로 변환하는 생성자 추가
+    public CommentDTO(Comment comment) {
+        this.commentId = comment.getId();
+        this.user_id = comment.getUserId();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+        // 자식 댓글이 있으면 DTO로 변환해서 리스트에 담는다.
+        if (comment.getChildren() != null) {
+            this.children = comment.getChildren().stream()
+                    .map(CommentDTO::new)
+                    .collect(Collectors.toList());
+        }
+    }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/TotalStatsDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/dto/TotalStatsDTO.java
@@ -1,0 +1,13 @@
+package com.ottrade.ottrade.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TotalStatsDTO {
+    private long totalUsers;
+    private long totalPosts;
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Board.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Board.java
@@ -1,0 +1,53 @@
+package com.ottrade.ottrade.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.sql.Timestamp;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "post")
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id" , nullable = false)
+    private Long user_id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String type;
+
+    @ColumnDefault("0")
+    private int view_count;
+
+    @CreationTimestamp
+    private Timestamp created_at;
+
+    @ColumnDefault("'ENABLE'")
+    @Column(name="status" ,nullable = false)
+    private String status;
+
+    @OneToMany(mappedBy = "post")
+    private Set<Comment> comments = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "board")
+    private Set<PostLike> postLikes = new LinkedHashSet<>();
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Board.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Board.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
+import jakarta.persistence.CascadeType; // CascadeType 임포트 추가
 
 import java.sql.Timestamp;
 import java.util.LinkedHashSet;
@@ -44,10 +45,11 @@ public class Board {
     @Column(name="status" ,nullable = false)
     private String status;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Comment> comments = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "board")
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<PostLike> postLikes = new LinkedHashSet<>();
+
 
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Board.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Board.java
@@ -35,11 +35,12 @@ public class Board {
     @Column(nullable = false)
     private String type;
 
+    // --- 아래 필드 2개를 수정합니다. ---
     @ColumnDefault("0")
-    private int view_count;
+    private int viewCount; // view_count -> viewCount 로 변경
 
     @CreationTimestamp
-    private Timestamp created_at;
+    private Timestamp createdAt; // created_at -> createdAt 으로 변경
 
     @ColumnDefault("'ENABLE'")
     @Column(name="status" ,nullable = false)

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
@@ -3,6 +3,9 @@ package com.ottrade.ottrade.domain.community.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.sql.Timestamp;
 
 @Getter
 @Setter
@@ -18,5 +21,17 @@ public class Comment {
     @JoinColumn(name = "post_id")
     private Board post;
 
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private Timestamp createdAt;
+
+    @Column(name = "status", nullable = false)
+    private String status;
     //TODO [Reverse Engineering] generate columns from DB
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -35,7 +37,16 @@ public class Comment {
     @Column(name = "status", nullable = false)
     private String status;
 
+    // --- 대댓글 기능을 위한 필드 추가 ---
 
+    // 부모 댓글 (ManyToOne 관계)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    // 자식 댓글 목록 (OneToMany 관계)
+    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>();
 
     //TODO [Reverse Engineering] generate columns from DB
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
@@ -1,0 +1,22 @@
+package com.ottrade.ottrade.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "comment", schema = "springuser")
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Board post;
+
+    //TODO [Reverse Engineering] generate columns from DB
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.ottrade.ottrade.domain.community.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -33,5 +34,8 @@ public class Comment {
 
     @Column(name = "status", nullable = false)
     private String status;
+
+
+
     //TODO [Reverse Engineering] generate columns from DB
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/PostLike.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/PostLike.java
@@ -1,0 +1,21 @@
+package com.ottrade.ottrade.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "post_like", schema = "springuser")
+public class PostLike {
+    @EmbeddedId
+    private PostLikeId id;
+
+    @MapsId("postId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Board board;
+
+    //TODO [Reverse Engineering] generate columns from DB
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/PostLikeId.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/entity/PostLikeId.java
@@ -1,0 +1,37 @@
+package com.ottrade.ottrade.domain.community.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.Hibernate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Setter
+@Embeddable
+public class PostLikeId implements Serializable {
+    private static final long serialVersionUID = 4260821407807592704L;
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        PostLikeId entity = (PostLikeId) o;
+        return Objects.equals(this.postId, entity.postId) &&
+                Objects.equals(this.userId, entity.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(postId, userId);
+    }
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/CommentRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/CommentRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long boardId);
+
+    void deleteAllByPostId(Long boardId);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/CommentRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.ottrade.ottrade.domain.community.repository;
+
+import com.ottrade.ottrade.domain.community.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPostId(Long boardId);
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/PostLikeRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/PostLikeRepository.java
@@ -1,0 +1,10 @@
+package com.ottrade.ottrade.domain.community.repository;
+
+import com.ottrade.ottrade.domain.community.entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    long countByBoardId(Long boardId);
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/PostLikeRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/PostLikeRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     long countByBoardId(Long boardId);
+
+    void deleteAllByBoardId(Long boardId);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/PostLikeRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/PostLikeRepository.java
@@ -4,9 +4,17 @@ import com.ottrade.ottrade.domain.community.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     long countByBoardId(Long boardId);
 
     void deleteAllByBoardId(Long boardId);
+
+    // findBy + {Id필드명} + _ + {Id필드 안의 postId 필드명} + And + {Id필드명} + _ + {Id필드 안의 userId 필드명}
+    Optional<PostLike> findById_PostIdAndId_UserId(Long postId, Long userId);
+
+    // deleteBy + {Id필드명} + _ + {Id필드 안의 postId 필드명} + And + {Id필드명} + _ + {Id필드 안의 userId 필드명}
+    void deleteById_PostIdAndId_UserId(Long postId, Long userId);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
@@ -1,0 +1,10 @@
+package com.ottrade.ottrade.domain.community.repository;
+
+import com.ottrade.ottrade.domain.community.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@org.springframework.stereotype.Repository
+public interface Repository extends JpaRepository<Board, Long> {
+
+
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
@@ -3,8 +3,10 @@ package com.ottrade.ottrade.domain.community.repository;
 import com.ottrade.ottrade.domain.community.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 @org.springframework.stereotype.Repository
 public interface Repository extends JpaRepository<Board, Long> {
 
-    public Board findByType(String type);
+    public List<Board> findByType(String type);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 @org.springframework.stereotype.Repository
 public interface Repository extends JpaRepository<Board, Long> {
 
-
+    public Board findByType(String type);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
@@ -2,6 +2,8 @@ package com.ottrade.ottrade.domain.community.repository;
 
 import com.ottrade.ottrade.domain.community.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.sql.Timestamp; // Timestamp 임포트 추가
 
 import java.util.List;
@@ -25,4 +27,10 @@ public interface Repository extends JpaRepository<Board, Long> {
      * @return 검색된 게시글 리스트
      */
     List<Board> findByTitleContainingOrContentContaining(String titleKeyword, String contentKeyword);
+
+    /**
+     * 게시글을 작성한 중복되지 않는 사용자의 총 수를 조회
+     */
+    @Query("SELECT COUNT(DISTINCT b.user_id) FROM Board b")
+    long countDistinctUsers();
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
@@ -17,4 +17,12 @@ public interface Repository extends JpaRepository<Board, Long> {
      * @return 조회수 높은 상위 10개 게시글 리스트
      */
     List<Board> findTop10ByCreatedAtAfterOrderByViewCountDesc(Timestamp date);
+
+    /**
+     * 제목 또는 내용에 특정 키워드가 포함된 게시글 목록 조회
+     * @param titleKeyword 제목에서 찾을 키워드
+     * @param contentKeyword 내용에서 찾을 키워드
+     * @return 검색된 게시글 리스트
+     */
+    List<Board> findByTitleContainingOrContentContaining(String titleKeyword, String contentKeyword);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/repository/Repository.java
@@ -2,6 +2,7 @@ package com.ottrade.ottrade.domain.community.repository;
 
 import com.ottrade.ottrade.domain.community.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.sql.Timestamp; // Timestamp 임포트 추가
 
 import java.util.List;
 
@@ -9,4 +10,11 @@ import java.util.List;
 public interface Repository extends JpaRepository<Board, Long> {
 
     public List<Board> findByType(String type);
+
+    /**
+     * 특정 날짜 이후에 작성된 게시글들을 조회수(view_count)가 높은 순으로 상위 10개 조회
+     * @param date 기준 날짜 (예: 7일 전)
+     * @return 조회수 높은 상위 10개 게시글 리스트
+     */
+    List<Board> findTop10ByCreatedAtAfterOrderByViewCountDesc(Timestamp date);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -1,11 +1,16 @@
 package com.ottrade.ottrade.domain.community.service;
 
+import com.ottrade.ottrade.domain.community.dto.AllBoardRespDTO;
 import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
 import com.ottrade.ottrade.domain.community.entity.Board;
 import com.ottrade.ottrade.domain.community.repository.Repository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,9 +35,17 @@ public class BoardService {
 
     }
 
-    public Object allBoard(String type) {
-        Board board = new Board();
-        return repository.findByType(type);
+    public List<AllBoardRespDTO> allBoard(String type) {
+        // 1. Repository를 통해 Board 엔티티 리스트를 조회합니다.
+        List<Board> boardList = repository.findByType(type);
 
+        // 2. Stream API를 사용하여 각 Board 엔티티를 AllBoardRespDTO로 변환합니다.
+        //    (fromEntity가 static 메소드라고 가정)
+        List<AllBoardRespDTO> dtoList = boardList.stream()
+                .map(board -> AllBoardRespDTO.fromEntity(board)) // 각 board를 DTO로 매핑
+                .collect(Collectors.toList()); // 결과를 List로 수집
+
+        // 3. 변환된 DTO 리스트를 반환합니다.
+        return dtoList;
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -29,4 +29,10 @@ public class BoardService {
         }
 
     }
+
+    public Object allBoard(String type) {
+        Board board = new Board();
+        return repository.findByType(type);
+
+    }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -1,0 +1,32 @@
+package com.ottrade.ottrade.domain.community.service;
+
+import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
+import com.ottrade.ottrade.domain.community.entity.Board;
+import com.ottrade.ottrade.domain.community.repository.Repository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final Repository repository;
+
+    @Transactional
+    public String boardWrite(BoardWriteDTO boardWriteDTO) {
+        Board board = new Board();
+        board.setUser_id(boardWriteDTO.getUser_id());
+        board.setTitle(boardWriteDTO.getTitle());
+        board.setContent(boardWriteDTO.getContent());
+        board.setType(boardWriteDTO.getType());
+        board.setStatus("enable");
+        try {
+            repository.save(board);
+            return "성공";
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -7,9 +7,12 @@ import com.ottrade.ottrade.domain.community.repository.CommentRepository;
 import com.ottrade.ottrade.domain.community.repository.PostLikeRepository;
 import com.ottrade.ottrade.domain.community.repository.Repository;
 import jakarta.transaction.Transactional;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -97,6 +100,35 @@ public class BoardService {
                 board.getUser_id(),
                 commentDTOs,
                 (int) likeCount
+        );
+    }
+
+    @Transactional
+    public CommentDTO createComment(Long boardId,/*String token, */CommentCreateRequest request, Long userId) {
+        /*// 인증 검증
+        if (!jwtUtil.validateToken(token)) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+        Long userId = jwtUtil.getUserIdFromToken(token);*/
+
+        // 게시글 존재 확인
+        Board board = repository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        // 댓글 엔티티 생성 및 저장
+        Comment comment = new Comment();
+        comment.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+        comment.setContent(request.getContent());
+        comment.setStatus("enable");
+        comment.setPost(board);
+        comment.setUserId(userId);
+        commentRepository.save(comment);
+
+        return new CommentDTO(
+                comment.getId(),
+                comment.getUserId(),
+                comment.getContent(),
+                comment.getCreatedAt()
         );
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -66,16 +66,16 @@ public class BoardService {
         return boardUpdate;
     }
 
-    @Transactional // 1. 트랜잭션 처리를 위해 어노테이션 추가
-    public void deleteBoard(Long boardId) { // 2. 반환 타입으로 void 명시
-
-        // 3. 삭제하려는 게시글이 존재하는지 먼저 확인
+    @Transactional
+    public void deleteBoard(Long boardId) {
         if (!repository.existsById(boardId)) {
-            // 존재하지 않으면 예외 발생 (이전에 만든 커스텀 예외 재활용)
             throw new IllegalArgumentException("ID " + boardId + "에 해당하는 게시글을 찾을 수 없습니다.");
         }
 
-        // 4. 존재하면 삭제 실행 (return 키워드 제거)
+        // 추가된 로직: 게시글에 연관된 댓글과 좋아요를 먼저 삭제합니다.
+        commentRepository.deleteAllByPostId(boardId);
+        postLikeRepository.deleteAllByBoardId(boardId); // PostLikeRepository에도 비슷한 메서드가 필요합니다.
+
         repository.deleteById(boardId);
     }
 

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.ottrade.ottrade.domain.community.service;
 
 import com.ottrade.ottrade.domain.community.dto.AllBoardRespDTO;
+import com.ottrade.ottrade.domain.community.dto.BoardUpdateReqDTO;
 import com.ottrade.ottrade.domain.community.dto.BoardWriteDTO;
 import com.ottrade.ottrade.domain.community.entity.Board;
 import com.ottrade.ottrade.domain.community.repository.Repository;
@@ -8,7 +9,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,5 +47,16 @@ public class BoardService {
 
         // 3. 변환된 DTO 리스트를 반환합니다.
         return dtoList;
+    }
+
+    @Transactional
+    public Board updateBoard(BoardUpdateReqDTO boardUpdateReqDTO) {
+        Board boardUpdate = repository.findById(boardUpdateReqDTO.getId())
+                .orElseThrow(() -> new IllegalArgumentException("ID " + boardUpdateReqDTO.getId() + "에 해당하는 게시글을 찾을 수 없습니다."));
+
+        boardUpdate.setTitle(boardUpdateReqDTO.getTitle());
+        boardUpdate.setContent(boardUpdateReqDTO.getContent());
+
+        return boardUpdate;
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -13,6 +13,7 @@ import com.ottrade.ottrade.domain.community.entity.PostLikeId;
 import java.util.Optional;
 import java.time.LocalDate; // LocalDate 임포트 추가
 import org.springframework.transaction.annotation.Transactional;
+import com.ottrade.ottrade.domain.community.dto.TotalStatsDTO; // TotalStatsDTO 임포트
 
 
 import java.sql.Timestamp;
@@ -240,5 +241,20 @@ public class BoardService {
 
         // 3. 변환된 DTO 리스트 반환
         return dtoList;
+    }
+
+    /**
+     * 총 사용자 수와 총 게시글 수 조회
+     */
+    @Transactional(readOnly = true)
+    public TotalStatsDTO getTotalStats() {
+        // 1. 총 게시글 수 조회
+        long totalPosts = repository.count();
+
+        // 2. 글을 작성한 총 사용자 수 조회
+        long totalUsers = repository.countDistinctUsers();
+
+        // 3. DTO에 담아 반환
+        return new TotalStatsDTO(totalUsers, totalPosts);
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -223,4 +223,22 @@ public class BoardService {
         // 4. 변환된 DTO 리스트 반환
         return dtoList;
     }
+
+    /**
+     * 게시글 검색 (제목 + 내용)
+     */
+    @Transactional(readOnly = true)
+    public List<AllBoardRespDTO> searchBoards(String keyword) {
+        // 1. Repository를 통해 키워드로 게시글 엔티티 리스트를 검색
+        // 제목과 내용 양쪽에서 모두 동일한 키워드로 검색
+        List<Board> searchResultList = repository.findByTitleContainingOrContentContaining(keyword, keyword);
+
+        // 2. 검색된 엔티티 리스트를 DTO 리스트로 변환
+        List<AllBoardRespDTO> dtoList = searchResultList.stream()
+                .map(AllBoardRespDTO::fromEntity)
+                .collect(Collectors.toList());
+
+        // 3. 변환된 DTO 리스트 반환
+        return dtoList;
+    }
 }

--- a/BackEnd/src/main/resources/application.properties
+++ b/BackEnd/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.servlet.context-path=/api
 server.port=8088
 
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3307/?user=com
+spring.datasource.url=jdbc:mysql://127.0.0.1:3307/springuser?user=com
 spring.datasource.username=com
 spring.datasource.password=com01
 


### PR DESCRIPTION
제목
feat: 커뮤니티 도메인 기능 전체 구현

Description
커뮤니티 서비스의 핵심 도메인인 community 관련 기능을 전체적으로 구현했습니다. 게시글, 댓글, 좋아요 등 기본적인 소셜 기능부터 HOT 게시판, 검색, 통계 조회 등 확장 기능까지 포함하여 사용자 중심의 동적인 커뮤니티 환경을 구축했습니다.

이번 PR을 통해 커뮤니티 기능의 백엔드 로직이 완성되었으며, 프론트엔드와의 연동을 위한 모든 API가 준비되었습니다.

주요 변경 사항 (Key Changes)
🚀 신규 기능 구현
게시글 (Board/Post)

게시글 작성, 전체/상세 조회, 수정, 삭제 (CRUD) API 구현

댓글 (Comment)

댓글 작성 및 조회 기능 구현

계층형 구조를 적용하여 대댓글 기능 구현

대댓글이 존재하는 댓글 삭제 시, 내용을 "삭제된 댓글입니다."로 변경하는 Soft Delete 방식 적용

좋아요 (PostLike)

게시글 좋아요 추가/취소 기능 구현

게시글 상세 조회 시, 총 좋아요 수를 함께 반환

확장 기능 API

HOT 게시글 조회 (GET /hot): 최근 7일간 조회수가 가장 높은 Top 10 게시글 목록 조회 기능

게시글 검색 (GET /search): 제목과 내용에 포함된 키워드로 게시글을 검색하는 기능

통계 조회 (GET /stats): 전체 게시글 수와 활동 사용자(글 작성자 기준) 수를 집계하는 기능

🔧 개선 및 수정
조회수 증가 로직 추가: 게시글 상세 조회 시, 해당 게시글의 viewCount가 1씩 증가하도록 로직을 개선했습니다.

영속성 관리: 게시글 삭제 시, 연관된 댓글과 좋아요가 함께 삭제되도록 Cascade 옵션을 설정했습니다.

JPA 명명 규칙 준수:

Board 엔티티의 필드명을 snake_case에서 camelCase로 수정하여 JPA 쿼리 메서드 오류를 해결했습니다. (created_at -> createdAt, view_count -> viewCount)

@EmbeddedId 복합키 필드를 참조하는 Repository 메서드 이름을 JPA 규칙에 맞게 수정하여 관련 오류를 해결했습니다.

트랜잭션 관리: 각 기능의 목적에 맞게 @Transactional 및 readOnly 속성을 적용하여 데이터의 일관성을 보장하고 성능을 최적화했습니다.

데이터베이스 변경 사항
comment 테이블에 대댓글 기능을 위해 자기 자신을 참조하는 parent_id 컬럼이 추가되었습니다.

전체 API 엔드포인트
GET /api/board: 타입별 게시글 전체 목록 조회

GET /api/board/detail/{boardId}: 게시글 상세 조회

GET /api/board/hot: HOT 게시글 목록 조회

GET /api/board/search?keyword={검색어}: 게시글 검색

GET /api/board/stats: 통계 조회

POST /api/board/write: 게시글 작성

PUT /api/board/update: 게시글 수정

DELETE /api/board/delete/{boardId}: 게시글 삭제

POST /api/board/{boardId}/{userId}/comments: 댓글/대댓글 작성

DELETE /api/board/{boardId}/comments/{commentId}: 댓글/대댓글 삭제

POST /api/board/{boardId}/{userId}/like: 좋아요 추가

DELETE /api/board/{boardId}/{userId}/like: 좋아요 취소