### PR TITLE
#feat5-mypage

### DIFF
--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/controller/LogController.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/controller/LogController.java
@@ -1,15 +1,18 @@
 package com.ottrade.ottrade.domain.log.controller;
 
+import com.ottrade.ottrade.domain.hssearch.dto.TradeTop3ResultDTO;
 import com.ottrade.ottrade.domain.log.dto.SearchLogResponseDTO;
 import com.ottrade.ottrade.domain.log.service.LogService;
 import com.ottrade.ottrade.global.util.ApiResponse;
 import com.ottrade.ottrade.security.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +32,15 @@ public class LogController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<SearchLogResponseDTO> history = logService.getSearchHistory(userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("내 검색 이력 조회 성공", history));
+    }
+
+    @GetMapping("/my-history/{logId}")
+    @Operation(summary = "특정 검색 이력 상세 조회", description = "특정 검색 이력 ID에 해당하는 과거 시점의 상세 데이터를 조회합니다.")
+    public ResponseEntity<ApiResponse<TradeTop3ResultDTO>> getSearchLogDetail(
+            @Parameter(description = "조회할 검색 이력의 ID") @PathVariable Long logId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        TradeTop3ResultDTO result = logService.getSearchLogDetail(logId);
+        return ResponseEntity.ok(ApiResponse.success("검색 이력 상세 조회 성공", result));
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/controller/LogController.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/controller/LogController.java
@@ -1,0 +1,33 @@
+package com.ottrade.ottrade.domain.log.controller;
+
+import com.ottrade.ottrade.domain.log.dto.SearchLogResponseDTO;
+import com.ottrade.ottrade.domain.log.service.LogService;
+import com.ottrade.ottrade.global.util.ApiResponse;
+import com.ottrade.ottrade.security.user.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Search History", description = "사용자별 검색 이력 조회 API")
+@RestController
+@RequestMapping("/api/logs")
+@RequiredArgsConstructor
+public class LogController {
+
+    private final LogService logService;
+
+    @GetMapping("/my-history")
+    @Operation(summary = "내 검색 이력 조회", description = "인증된 사용자의 HS코드 검색 이력 목록을 최신순으로 조회합니다.")
+    public ResponseEntity<ApiResponse<List<SearchLogResponseDTO>>> getMySearchHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<SearchLogResponseDTO> history = logService.getSearchHistory(userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("내 검색 이력 조회 성공", history));
+    }
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/dto/SearchLogResponseDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/dto/SearchLogResponseDTO.java
@@ -1,0 +1,20 @@
+package com.ottrade.ottrade.domain.log.dto;
+
+import com.ottrade.ottrade.domain.log.entity.SearchLog;
+import lombok.Getter;
+import java.sql.Timestamp;
+
+@Getter
+public class SearchLogResponseDTO {
+    private final Long id;
+    private final String keyword; // HS Code
+    private final Timestamp searchedAt;
+    private final String gptSummary;
+
+    public SearchLogResponseDTO(SearchLog log) {
+        this.id = log.getId();
+        this.keyword = log.getKeyword();
+        this.searchedAt = log.getSearchedAt();
+        this.gptSummary = log.getGptSummary();
+    }
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/repository/SearchLogRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/repository/SearchLogRepository.java
@@ -4,6 +4,7 @@ import com.ottrade.ottrade.domain.log.entity.SearchLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional; // Optional 임포트
 
 @Repository
@@ -11,4 +12,6 @@ public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
 
     // 사용자 ID와 키워드로 로그를 찾는 메소드 추가
     Optional<SearchLog> findByUserIdAndKeyword(Long userId, String keyword);
+    // 사용자의 모든 검색 기록을 최신순으로 조회하는 메소드 추가
+    List<SearchLog> findAllByUserIdOrderBySearchedAtDesc(Long userId);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
@@ -1,5 +1,6 @@
 package com.ottrade.ottrade.domain.log.service;
 
+import com.ottrade.ottrade.domain.log.dto.SearchLogResponseDTO;
 import com.ottrade.ottrade.domain.log.entity.PnmLog;
 import com.ottrade.ottrade.domain.log.entity.SearchLog; // SearchLog 임포트
 import com.ottrade.ottrade.domain.log.repository.PnmLogRepository;
@@ -7,6 +8,9 @@ import com.ottrade.ottrade.domain.log.repository.SearchLogRepository; // SearchL
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +43,18 @@ public class LogService {
         searchLog.setKeyword(hsCode);
         // gptSummary는 AI 분석 시점에 채워지므로 여기서는 비워둡니다.
         searchLogRepository.save(searchLog);
+    }
+
+    /**
+     * 내 검색 이력 조회
+     * @param userId 현재 로그인한 사용자의 ID
+     * @return 검색 이력 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<SearchLogResponseDTO> getSearchHistory(Long userId) {
+        return searchLogRepository.findAllByUserIdOrderBySearchedAtDesc(userId)
+                .stream()
+                .map(SearchLogResponseDTO::new)
+                .collect(Collectors.toList());
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
@@ -1,14 +1,17 @@
 package com.ottrade.ottrade.domain.log.service;
 
+import com.ottrade.ottrade.domain.hssearch.dto.TradeTop3ResultDTO;
+import com.ottrade.ottrade.domain.hssearch.service.TradeApiService;
 import com.ottrade.ottrade.domain.log.dto.SearchLogResponseDTO;
 import com.ottrade.ottrade.domain.log.entity.PnmLog;
-import com.ottrade.ottrade.domain.log.entity.SearchLog; // SearchLog 임포트
+import com.ottrade.ottrade.domain.log.entity.SearchLog;
 import com.ottrade.ottrade.domain.log.repository.PnmLogRepository;
-import com.ottrade.ottrade.domain.log.repository.SearchLogRepository; // SearchLogRepository 임포트
+import com.ottrade.ottrade.domain.log.repository.SearchLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,43 +21,36 @@ import java.util.stream.Collectors;
 public class LogService {
 
     private final PnmLogRepository pnmLogRepository;
-    private final SearchLogRepository searchLogRepository; // 주석 해제
+    private final SearchLogRepository searchLogRepository;
+    private final TradeApiService tradeApiService; // TradeApiService 주입
 
-    /**
-     * 품목명(prnm) 검색 기록 저장
-     * @param prnm 검색한 품목명
-     */
     public void savePnmLog(String prnm) {
         PnmLog pnmLog = new PnmLog();
         pnmLog.setPnm(prnm);
         pnmLogRepository.save(pnmLog);
     }
 
-    /**
-     * HS코드 검색 기록 저장 (구현)
-     * @param hsCode 검색한 HS코드
-     * @param userId 검색한 사용자의 ID
-     */
     public void saveHsCodeSearchLog(String hsCode, Long userId) {
-        // 이전에 같은 검색을 했는지 확인하지 않고, 항상 새로운 로그로 저장합니다.
-        // 만약 중복 저장을 막고 싶다면 findByUserIdAndKeyword 로직을 추가할 수 있습니다.
         SearchLog searchLog = new SearchLog();
         searchLog.setUserId(userId);
         searchLog.setKeyword(hsCode);
-        // gptSummary는 AI 분석 시점에 채워지므로 여기서는 비워둡니다.
         searchLogRepository.save(searchLog);
     }
 
-    /**
-     * 내 검색 이력 조회
-     * @param userId 현재 로그인한 사용자의 ID
-     * @return 검색 이력 DTO 리스트
-     */
     @Transactional(readOnly = true)
     public List<SearchLogResponseDTO> getSearchHistory(Long userId) {
         return searchLogRepository.findAllByUserIdOrderBySearchedAtDesc(userId)
                 .stream()
                 .map(SearchLogResponseDTO::new)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public TradeTop3ResultDTO getSearchLogDetail(Long logId) {
+        SearchLog log = searchLogRepository.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 검색 이력입니다."));
+
+        LocalDateTime searchedAt = log.getSearchedAt().toLocalDateTime();
+        return tradeApiService.fetchTradeStatsByLog(log.getKeyword(), null, searchedAt);
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/config/SecurityConfig.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                         // AI 분석 API 모든 사용자에게 허용 (이 부분을 수정!)
                         .requestMatchers("/gpt/**").permitAll()
                         // 내 정보 조회는 'USER', 'ADMIN' 역할 필요 (수정됨)
-                        .requestMatchers("/api/users/me").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/users/me", "/api/logs/**").hasAnyRole("USER", "ADMIN")
                         // 나머지 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 );


### PR DESCRIPTION
1. 과거 시점 데이터 조회 기능 구현
   TradeApiService 수정:

기존의 fetchTop3TradeStats 메소드를 오버로딩하여, 기준 날짜(LocalDate)를 파라미터로 받아 해당 날짜 기준으로 통계 데이터를 조회하는 핵심 로직을 구현했습니다.

외부 API를 호출하는 fetchLastYearTrade, fetchGroupedTradeList 등의 내부 메소드들도 기준 날짜를 사용하도록 수정했습니다.

fetchTradeStatsByLog라는 새로운 public 메소드를 추가하여, LocalDateTime 타입의 검색 시간을 받아 과거 시점 조회를 쉽게 요청할 수 있도록 했습니다.

LogService 수정:

getSearchLogDetail 메소드를 추가했습니다. 이 메소드는 logId로 검색 이력을 찾은 후, 해당 이력의 searchedAt (검색 시간)과 keyword (HS 코드)를 TradeApiService에 전달하여 과거 시점의 상세 데이터를 가져옵니다.

2. 신규 API 엔드포인트 추가
   LogController 수정:

GET /api/logs/my-history/{logId} 엔드포인트를 새로 추가했습니다.

사용자가 조회 이력 목록에서 특정 항목을 클릭하면, 프론트엔드에서 이 API를 호출하여 해당 logId에 대한 과거 시점의 상세 데이터를 받아올 수 있습니다.

✅ 테스트 방법
조회 이력 생성: 먼저 여러 HS코드를 검색하여 조회 이력을 충분히 생성합니다.

이력 목록 조회: GET /api/logs/my-history API를 호출하여 이력 목록과 각 이력의 id를 확인합니다.

과거 시점 상세 조회: 위에서 확인한 id 중 하나를 사용하여 GET /api/logs/my-history/{logId} API를 호출합니다.

결과 확인:

API가 성공적으로 과거 시점의 Top3 국가 및 통계 데이터를 반환하는지 확인합니다.

(선택) 데이터베이스의 search_log 테이블에서 해당 logId의 searched_at 날짜를 확인하고, 반환된 데이터가 그 시점을 기준으로 계산된 것이 맞는지 검증합니다. (예: "전년도"가 searched_at의 -1년으로 계산되었는지 확인)