### PR TITLE
#feat6-prnmrank

### DIFF
--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/community/service/BoardService.java
@@ -206,9 +206,6 @@ public class BoardService {
     /**
      * HOT 게시글 조회 (최근 7일간 조회수 TOP 10)
      */
-    /**
-     * HOT 게시글 조회 (최근 7일간 조회수 TOP 10)
-     */
     @Transactional(readOnly = true) // 이제 이 어노테이션이 정상 동작합니다.
     public List<AllBoardRespDTO> getHotBoards() {
         // 1. 기준 날짜 설정 (7일 전)

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/controller/LogController.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/controller/LogController.java
@@ -2,6 +2,7 @@ package com.ottrade.ottrade.domain.log.controller;
 
 import com.ottrade.ottrade.domain.hssearch.dto.TradeTop3ResultDTO;
 import com.ottrade.ottrade.domain.log.dto.SearchLogResponseDTO;
+import com.ottrade.ottrade.domain.log.dto.TopSearchKeywordDTO;
 import com.ottrade.ottrade.domain.log.service.LogService;
 import com.ottrade.ottrade.global.util.ApiResponse;
 import com.ottrade.ottrade.security.user.CustomUserDetails;
@@ -42,5 +43,12 @@ public class LogController {
 
         TradeTop3ResultDTO result = logService.getSearchLogDetail(logId);
         return ResponseEntity.ok(ApiResponse.success("검색 이력 상세 조회 성공", result));
+    }
+
+    @GetMapping("/top-keywords")
+    @Operation(summary = "인기 검색어 Top 10 조회", description = "사용자들이 가장 많이 검색한 품목명 순위 10개를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<TopSearchKeywordDTO>>> getTopSearchKeywords() {
+        List<TopSearchKeywordDTO> topKeywords = logService.getTop10SearchKeywords();
+        return ResponseEntity.ok(ApiResponse.success("인기 검색어 조회 성공", topKeywords));
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/dto/TopSearchKeywordDTO.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/dto/TopSearchKeywordDTO.java
@@ -1,0 +1,14 @@
+package com.ottrade.ottrade.domain.log.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TopSearchKeywordDTO {
+    private final String keyword;
+    private final long searchCount;
+
+    public TopSearchKeywordDTO(String keyword, long searchCount) {
+        this.keyword = keyword;
+        this.searchCount = searchCount;
+    }
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/repository/PnmLogRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/repository/PnmLogRepository.java
@@ -2,11 +2,12 @@ package com.ottrade.ottrade.domain.log.repository;
 
 import com.ottrade.ottrade.domain.log.dto.TopSearchKeywordDTO;
 import com.ottrade.ottrade.domain.log.entity.PnmLog;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.awt.print.Pageable;
+
 import java.util.List;
 
 @Repository
@@ -16,9 +17,9 @@ public interface PnmLogRepository extends JpaRepository<PnmLog, Long> {
      * @param pageable Top 10을 지정하기 위한 페이징 정보
      * @return Top 10 검색어와 횟수가 담긴 DTO 리스트
      */
-    @Query("SELECT new com.ottrade.ottrade.domain.log.dto.TopSearchKeywordDTO(p.pnm, COUNT(p.pnm)) " +
+    @Query("SELECT p.pnm, COUNT(p.pnm) " +
             "FROM PnmLog p " +
             "GROUP BY p.pnm " +
             "ORDER BY COUNT(p.pnm) DESC")
-    List<TopSearchKeywordDTO> findTopKeywords(Pageable pageable);
+    List<Object[]> findTopKeywords(Pageable pageable);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/repository/PnmLogRepository.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/repository/PnmLogRepository.java
@@ -1,9 +1,24 @@
 package com.ottrade.ottrade.domain.log.repository;
 
+import com.ottrade.ottrade.domain.log.dto.TopSearchKeywordDTO;
 import com.ottrade.ottrade.domain.log.entity.PnmLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.awt.print.Pageable;
+import java.util.List;
 
 @Repository
 public interface PnmLogRepository extends JpaRepository<PnmLog, Long> {
+    /**
+     * 가장 많이 검색된 품목명(pnm) Top 10을 조회하는 쿼리
+     * @param pageable Top 10을 지정하기 위한 페이징 정보
+     * @return Top 10 검색어와 횟수가 담긴 DTO 리스트
+     */
+    @Query("SELECT new com.ottrade.ottrade.domain.log.dto.TopSearchKeywordDTO(p.pnm, COUNT(p.pnm)) " +
+            "FROM PnmLog p " +
+            "GROUP BY p.pnm " +
+            "ORDER BY COUNT(p.pnm) DESC")
+    List<TopSearchKeywordDTO> findTopKeywords(Pageable pageable);
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
@@ -10,10 +10,11 @@ import com.ottrade.ottrade.domain.log.repository.PnmLogRepository;
 import com.ottrade.ottrade.domain.log.repository.SearchLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.print.Pageable;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -58,12 +59,20 @@ public class LogService {
     }
 
     /**
-     * [신규] 인기 검색어 Top 10 조회 서비스
+     *인기 검색어 Top 10 조회 서비스
      * @return 인기 검색어 DTO 리스트
      */
     @Transactional(readOnly = true)
     public List<TopSearchKeywordDTO> getTop10SearchKeywords() {
-        // 첫 페이지의 10개 항목을 가져오도록 Pageable 객체 생성
-        return pnmLogRepository.findTopKeywords((Pageable) PageRequest.of(0, 10));
+        // 올바른 클래스를 import하면 (Pageable) 형변환이 필요 없습니다.
+        Pageable topTen = PageRequest.of(0, 10);
+        List<Object[]> results = pnmLogRepository.findTopKeywords(topTen);
+
+        return results.stream()
+                .map(result -> new TopSearchKeywordDTO(
+                        (String) result[0],
+                        ((Number) result[1]).longValue()
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/log/service/LogService.java
@@ -3,14 +3,17 @@ package com.ottrade.ottrade.domain.log.service;
 import com.ottrade.ottrade.domain.hssearch.dto.TradeTop3ResultDTO;
 import com.ottrade.ottrade.domain.hssearch.service.TradeApiService;
 import com.ottrade.ottrade.domain.log.dto.SearchLogResponseDTO;
+import com.ottrade.ottrade.domain.log.dto.TopSearchKeywordDTO;
 import com.ottrade.ottrade.domain.log.entity.PnmLog;
 import com.ottrade.ottrade.domain.log.entity.SearchLog;
 import com.ottrade.ottrade.domain.log.repository.PnmLogRepository;
 import com.ottrade.ottrade.domain.log.repository.SearchLogRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -52,5 +55,15 @@ public class LogService {
 
         LocalDateTime searchedAt = log.getSearchedAt().toLocalDateTime();
         return tradeApiService.fetchTradeStatsByLog(log.getKeyword(), null, searchedAt);
+    }
+
+    /**
+     * [신규] 인기 검색어 Top 10 조회 서비스
+     * @return 인기 검색어 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<TopSearchKeywordDTO> getTop10SearchKeywords() {
+        // 첫 페이지의 10개 항목을 가져오도록 Pageable 객체 생성
+        return pnmLogRepository.findTopKeywords((Pageable) PageRequest.of(0, 10));
     }
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/config/SecurityConfig.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/config/SecurityConfig.java
@@ -42,11 +42,12 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/board/**").permitAll()
                         // HS코드 검색 관련 GET 요청 허용
                         .requestMatchers(HttpMethod.GET, "/search-summary/**", "/grouped/**", "/top3/**").permitAll()
-                        // Swagger UI 접근 허용 (이 부분을 추가!)
+                        .requestMatchers(HttpMethod.GET, "/api/logs/top-keywords").permitAll()
+                        // Swagger UI 접근 허용
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        // AI 분석 API 모든 사용자에게 허용 (이 부분을 수정!)
+                        // AI 분석 API 모든 사용자에게 허용
                         .requestMatchers("/gpt/**").permitAll()
-                        // 내 정보 조회는 'USER', 'ADMIN' 역할 필요 (수정됨)
+                        // 내 정보 조회는 'USER', 'ADMIN' 역할 필요
                         .requestMatchers("/api/users/me", "/api/logs/**").hasAnyRole("USER", "ADMIN")
                         // 나머지 모든 요청은 인증 필요
                         .anyRequest().authenticated()


### PR DESCRIPTION
1. 인기 검색어 TOP 10 조회 기능 추가 📈
   기능: 사용자들이 가장 많이 검색한 품목명(pnm) 순위 10개를 조회하는 API를 구현했습니다.

API 엔드포인트: GET /api/logs/top-keywords

적용된 파일:

PnmLogRepository.java: 품목명(pnm)으로 그룹화하고 개수를 세어 정렬하는 커스텀 JPQL 쿼리를 추가했습니다.

LogService.java: pnmLogRepository를 호출하여 인기 검색어 목록을 조회하는 getTop10SearchKeywords 로직을 구현했습니다.

LogController.java: API 요청을 받아 처리하는 컨트롤러 메소드를 추가했습니다.

TopSearchKeywordDTO.java: 쿼리 결과를 담을 DTO를 새로 생성했습니다.

2. 버그 수정 및 안정성 개선 🛠️
   401 Unauthorized 오류 해결: 새로 추가된 인기 검색어 API(/api/logs/top-keywords)는 누구나 접근할 수 있어야 하므로, SecurityConfig.java에 permitAll() 규칙을 추가하여 인증 없이도 호출할 수 있도록 수정했습니다.

500 Internal Server Error 해결:

원인: JPQL 쿼리에서 DTO를 직접 생성할 때, 데이터베이스가 반환하는 COUNT 값의 숫자 타입(예: BigInteger)과 DTO 생성자가 기대하는 Long 타입이 달라 ClassCastException이 발생했습니다.

해결: Repository에서는 Object[] 타입으로 안전하게 데이터를 받고, Service 단에서 ((Number) result[1]).longValue()와 같이 유연하게 타입을 변환하여 DTO를 생성하도록 수정했습니다.

잘못된 Import 수정: PnmLogRepository에서 java.awt.print.Pageable을 잘못 import 하고 있던 문제를 org.springframework.data.domain.Pageable로 바로잡아 IDE 및 빌드 오류를 해결했습니다.