### PR TITLE
fix: 마이페이지,구글테스트

### DIFF
--- a/BackEnd/src/main/java/com/ottrade/ottrade/OttradeApplication.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/OttradeApplication.java
@@ -2,8 +2,6 @@ package com.ottrade.ottrade;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 public class OttradeApplication {

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/controller/AuthController.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/controller/AuthController.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,7 +33,6 @@ public class AuthController {
     private final AuthService authService;
     private final JwtUtil jwtUtil;
 
-    //컨트롤러
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody AuthDto.SignUpRequest request) {
@@ -90,7 +88,7 @@ public class AuthController {
     public ResponseEntity<?> withdraw(
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-//        String accessToken = jwtUtil.extractToken(accessTokenHeader); // "Bearer " 제거
+       //String accessToken = jwtUtil.extractToken(accessTokenHeader); // "Bearer " 제거
         authService.withdraw(userDetails, userDetails.getUser());
         return ResponseEntity.ok("회원탈퇴 완료");
     }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/controller/UserController.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/controller/UserController.java
@@ -1,22 +1,33 @@
 package com.ottrade.ottrade.domain.member.controller;
 
+import com.ottrade.ottrade.domain.member.dto.AuthDto;
+import com.ottrade.ottrade.domain.member.service.UserService; // UserService 임포트
+import com.ottrade.ottrade.global.util.ApiResponse;
+import com.ottrade.ottrade.security.user.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ottrade.ottrade.domain.member.dto.AuthDto;
-import com.ottrade.ottrade.global.util.ApiResponse;
-import com.ottrade.ottrade.security.user.CustomUserDetails;
-
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/users")
+@RequiredArgsConstructor
 public class UserController {
 
+    private final UserService userService; 
+
+    	
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<AuthDto.UserInfoResponse>> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        AuthDto.UserInfoResponse userInfo = AuthDto.UserInfoResponse.fromEntity(userDetails.getUser());
+    public ResponseEntity<ApiResponse<AuthDto.UserInfoResponse>> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        // 실제 로직 처리는 서비스 계층에 위임합니다.
+        AuthDto.UserInfoResponse userInfo = userService.getMyInfo(userDetails);
+
+        // 서비스로부터 받은 결과를 최종 응답 형태로 만들어 반환합니다.
         return ResponseEntity.ok(ApiResponse.success("내 정보 조회 성공", userInfo));
     }
 }
+

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/service/AuthService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/service/AuthService.java
@@ -38,9 +38,7 @@ public class AuthService {
     private final RefreshRepository refreshRepository;
     private final SearchLogRepository searchLogRepository;
 	
-	
 
-	
 	// 회원가입
 	@Transactional
 	public void signup(AuthDto.SignUpRequest request) {
@@ -56,8 +54,7 @@ public class AuthService {
 	}
 
 	
-	
-	// 일반로그인
+	//일반로그인
 	@Transactional
 	public AuthDto.TokenResponse login(AuthDto.LoginRequest request) {
 		User user = userRepository.findByPhone(request.getPhone())
@@ -70,28 +67,26 @@ public class AuthService {
 	}
 
 	
-	
-	//토근 재발급
+	//토근 재발급요청 
 	@Transactional
 	public AuthDto.TokenResponse reissueToken(AuthDto.ReissueRequest request) {
 		String refreshToken = request.getRefreshToken();
 
-		// 1. 리프레시 토큰 유효성 검증
+		//리프레시 토큰 유효성 검증
 		if (!jwtUtil.validateToken(refreshToken)) {
 			throw new CustomException(ErrorCode.INVALID_TOKEN, "유효하지 않은 리프레시 토큰입니다.");
 		}
 
-		// 2. DB의 토큰과 일치하는지 확인
+		//DB의 토큰과 일치하는지 확인
 		User user = userRepository.findByRefreshToken(refreshToken)
 				.orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다. 다시 로그인해주세요."));
 
-		// 3. 새로운 토큰 발급
+		//새로운 토큰 발급
 		return issueTokens(user);
 	}
-
 	
 	
-	// 로그인 및 소셜 로그인 성공 시 토큰 발급
+	//로그인,소셜로그인 성공시 토큰발급,재발급 
 	@Transactional
 	public AuthDto.TokenResponse issueTokens(User user) {
 		String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole());
@@ -101,13 +96,12 @@ public class AuthService {
 
 		return AuthDto.TokenResponse.builder().accessToken(accessToken).refreshToken(refreshToken).build();
 	}
+	
 
-	
-	
-	// 로그아웃
+
+	// 로그아웃 (로그아웃순서모음)
 	@Transactional 
 	public void logout(String accessToken, String refreshToken) {
-	   //로그아웃 순서를 명시해주는 -> 메서드
 		validateAccessTokenOrThrow(accessToken);
 		deleteRefreshTokenFromDB(refreshToken);
 //		blacklistAccessToken(accessToken);

--- a/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/service/UserService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/domain/member/service/UserService.java
@@ -1,0 +1,21 @@
+package com.ottrade.ottrade.domain.member.service;
+
+
+import com.ottrade.ottrade.domain.member.dto.AuthDto;
+import com.ottrade.ottrade.security.user.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 조회 기능이므로 readOnly = true 설정
+public class UserService {
+
+    
+    public AuthDto.UserInfoResponse getMyInfo(CustomUserDetails userDetails) {
+
+        return AuthDto.UserInfoResponse.fromEntity(userDetails.getUser());
+    }
+}

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/config/SecurityConfig.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-    // 보안이 어떻게 처리되는지를 정의 
+    // 외부에서 들어온 요청에 대해 보안 
     
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/filter/JwtAuthenticationFilter.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/filter/JwtAuthenticationFilter.java
@@ -23,12 +23,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService customUserDetailsService;
-    // 요청된 URL을 확인해서 검출하는곳
+    //로그인되고 요청이 들어올때 Filter가 가로챔 (필터)
     
     
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        // 필터를 거치지 않을 경로들을 배열로 설정
+        // 필터를 거치지 않을 경로들을 배열로 설정 
         String[] CROSNotFilterArray = {
             "/auth/reissue",
             "/auth/signup",
@@ -47,9 +47,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return false; // 필터를 거침
     }
 
-
-
-    @Override
+     
+    @Override //필터로 추출해서 SecurityContext에 저장 
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtUtil.resolveToken(request);
 

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/handler/OAuth2LoginSuccessHandler.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/handler/OAuth2LoginSuccessHandler.java
@@ -22,24 +22,21 @@ import lombok.RequiredArgsConstructor;
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final AuthService authService;
-    // 소셜 서비스 성공후 후처리 
+    // 구글 로그인 후,  로그인 완료 페이지로 이동하면서 필요한 토큰 전달하는 클래스
     
     
     // application.properties에서 프론트엔드 리디렉션 주소를 주입받음
     @Value("${oauth.redirect-uri.frontend}")
     private String frontendRedirectUri;
 
-    @Override
+    @Override  //AuthService 로 우리쪽 전용토큰발급 , 리디렉션할 URL 생성후 리디렉션
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
 
-        // AuthService를 통해 우리 서비스 전용 토큰 발급
         AuthDto.TokenResponse tokenResponse = authService.issueTokens(oAuth2User.getUser());
 
-        // 리디렉션할 URL 생성
         String targetUrl = createRedirectUrl(tokenResponse);
 
-        // 생성된 URL로 리디렉션
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/user/CustomOAuth2UserService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/user/CustomOAuth2UserService.java
@@ -22,62 +22,59 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-    private final UserRepository userRepository;
-    // 소셜서비스 에서 반환되는곳 
-    
-    @Override
-    @Transactional
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // 2 소셜서비스 에서 반환된 정보를 객체화 
-        OAuth2User oAuth2User = super.loadUser(userRequest);
+	private final UserRepository userRepository;
+	// 소셜 로그인 후, 제공된 사용자 정보를 DB에서 찾고 없으면 새로 등록하며, 스프링 시큐리티가 사용할 사용자 상세정보 객체를 반환하는 서비스 클래스
 
-        //  소셜 서비스 제공자(Google, Kakao 등)에 따라 정보를 분기 처리
-        OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(userRequest, oAuth2User.getAttributes());
+	@Override
+	@Transactional
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		// 메서드 모음
+		
+		// 소셜서비스 에서 반환된 정보를 객체화
+		OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        //  DB에서 유저를 찾거나 새로 생성
-        User user = findOrCreateUser(oAuth2UserInfo);
+		// 소셜 서비스 제공자(Google, Kakao 등)에 따라 정보를 분기 처리
+		OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(userRequest, oAuth2User.getAttributes());
 
-        //  Spring Security가 관리할 수 있는 형태로 반환
-        return new CustomUserDetails(user, oAuth2User.getAttributes());
-    }
+		// DB에서 유저를 찾거나 새로 생성
+		User user = findOrCreateUser(oAuth2UserInfo);
 
-    	// 소셜 서비스 제공자에 따라 적절한 OAuth2UserInfo 객체를 생성하는 메소드
-    private OAuth2UserInfo getOAuth2UserInfo(OAuth2UserRequest userRequest, Map<String, Object> attributes) {
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		// Spring Security가 관리할 수 있는 형태로 반환
+		return new CustomUserDetails(user, oAuth2User.getAttributes());
+	}
 
-        if (registrationId.equals("google")) {
-            return new GoogleUserInfo(attributes);}
+	// 소셜 서비스 제공자에 따라 적절한 OAuth2UserInfo 객체를 생성하는 메소드
+	private OAuth2UserInfo getOAuth2UserInfo(OAuth2UserRequest userRequest, Map<String, Object> attributes) {
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+		if (registrationId.equals("google")) {
+			return new GoogleUserInfo(attributes);
+		}
 //        } else if (registrationId.equals("kakao")) {
 //            return new KakaoUserInfo(attributes);
 //        }
-        // 향후 Naver, Facebook 등 다른 제공자 추가 시 여기에 'else if'를 추가
+		// 향후 Naver, Facebook 등 다른 제공자 추가 시 여기에 'else if'를 추가
 
-        throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
-    }
+		throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+	}
 
-    // DB에서 유저 정보를 찾고, 없다면 새로 생성하는 메소드
-    private User findOrCreateUser(OAuth2UserInfo oAuth2UserInfo) {
-        String email = oAuth2UserInfo.getEmail();
+	// DB에서 유저 정보를 찾고, 없다면 새로 생성하는 메소드
+	private User findOrCreateUser(OAuth2UserInfo oAuth2UserInfo) {
+		String email = oAuth2UserInfo.getEmail();
 
-        return userRepository.findByEmail(email)
-                .map(existingUser -> existingUser.updateOAuthInfo(
-                        oAuth2UserInfo.getName(),
-                        oAuth2UserInfo.getProvider(),
-                        oAuth2UserInfo.getProviderId()
-                ))
-                .orElseGet(() -> createNewUser(oAuth2UserInfo));
-    }
+		return userRepository.findByEmail(email)
+				.map(existingUser -> existingUser.updateOAuthInfo(oAuth2UserInfo.getName(),
+						oAuth2UserInfo.getProvider(), oAuth2UserInfo.getProviderId()))
+				.orElseGet(() -> createNewUser(oAuth2UserInfo));
+	}
 
-    // 새로운 유저를 생성하는 메소드
-    private User createNewUser(OAuth2UserInfo oAuth2UserInfo) {
-        User newUser = User.builder()
-                .email(oAuth2UserInfo.getEmail())
-                .nickname(oAuth2UserInfo.getName())
-                .provider(oAuth2UserInfo.getProvider())
-                .providerId(oAuth2UserInfo.getProviderId())
-                .password(UUID.randomUUID().toString()) // 임의의 비밀번호 생성
-                .role(Role.user) // 기본 역할 부여
-                .build();
-        return userRepository.save(newUser);
-    }
+	// 새로운 유저를 생성하는 메소드
+	private User createNewUser(OAuth2UserInfo oAuth2UserInfo) {
+		User newUser = User.builder().email(oAuth2UserInfo.getEmail()).nickname(oAuth2UserInfo.getName())
+				.provider(oAuth2UserInfo.getProvider()).providerId(oAuth2UserInfo.getProviderId())
+				.password(UUID.randomUUID().toString()) // 임의의 비밀번호 생성
+				.role(Role.user) // 기본 역할 부여
+				.build();
+		return userRepository.save(newUser);
+	}
 }

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/user/CustomUserDetails.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/user/CustomUserDetails.java
@@ -19,7 +19,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
     private final User user;
     private Map<String, Object> attributes;
     private static final long serialVersionUID = 1L;
-    // DB에서 데이터를 Security가 이해할수있게 신분증 생성하는곳  
+    // DB에서 데이터를 Security가 이해할수있게 신분증 생성하는 클래스  
     
     // 일반 로그인 생성자
     public CustomUserDetails(User user) {

--- a/BackEnd/src/main/java/com/ottrade/ottrade/security/user/CustomUserDetailsService.java
+++ b/BackEnd/src/main/java/com/ottrade/ottrade/security/user/CustomUserDetailsService.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
-    // 역할(신분증)발급기관 	
+    // 역할(신분증)발급기관 클래스
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         User user = userRepository.findById(Long.parseLong(userId))

--- a/BackEnd/src/main/resources/application.properties
+++ b/BackEnd/src/main/resources/application.properties
@@ -42,7 +42,7 @@ spring.security.oauth2.client.registration.google.scope=email,profile
 # =======================================
 spring.config.import=optional:classpath:application-secret.properties
 
-oauth.redirect-uri.frontend=http://localhost:3000/auth/callback
+oauth.redirect-uri.frontend=http://localhost:5173/auth/callback
 spring.jpa.properties.hibernate.format_sql = true
 
 unipass.api.key=u270s265f066q055p020m090z0


### PR DESCRIPTION
feat: 구글 소셜 로그인 및 회원 기능 구현

설명
구글 소셜 로그인 및 JWT 기반 회원 관리(내 정보 조회, 로그아웃, 회원 탈퇴) 기능을 구현했습니다.

주요 기능
구글 소셜 로그인: 성공 시 JWT 토큰 발급 및 신규 유저 자동 가입

회원 관리 API:

GET /api/users/me: 내 정보 조회

POST /api/auth/logout: 로그아웃 (토큰 무효화)

DELETE /api/users/me: 회원 탈퇴 (데이터 및 토큰 삭제)

테스트 확인 사항
소셜 로그인: 브라우저에서 /api/oauth2/authorization/google 접속 후, 콜백 URL로 토큰이 정상적으로 전달되는지 확인.

API 테스트: Postman에서 발급받은 Access Token을 Bearer 토큰으로 설정 후, /api/users/me 등 보호된 API가 정상 동작하는지 확인.

참고
카카오 로그인은 추후 구현 예정입니다.

실행을 위해 application-secret.properties 파일에 환경 변수 설정이 필요합니다.
